### PR TITLE
Fix missing default string support

### DIFF
--- a/src/main/java/marvtechnology/customTownCleanup/util/YamlStore.java
+++ b/src/main/java/marvtechnology/customTownCleanup/util/YamlStore.java
@@ -42,6 +42,10 @@ public final class YamlStore {
     public void save()                         { try { conf.save(file); } catch (IOException e) { plugin.getLogger().log(Level.SEVERE, "保存失敗", e); } }
     public boolean contains(String p)          { return conf.contains(p); }
     public String  getString(String p)         { return conf.getString(p); }
+    public String  getString(String p, String def) {
+        String v = conf.getString(p);
+        return v != null ? v : def;
+    }
     public long    getLong(String p, long def) { return conf.getLong(p, def); }
     public boolean getBoolean(String p, boolean def){ return conf.getBoolean(p, def); }
     public void    set(String p, Object v)     { conf.set(p, v); }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,7 +3,8 @@ cleanup:
   interval-seconds: 86400   # 24時間ごとにチェックしたい場合は 86400
 
 # Discord 通知用 Webhook URL（削除1日前の警告に使用）
-discord_webhook_url: "https://discord.com/api/webhooks/1394235685514379285/W4eBscSdN2B4zaAoJKM_5fj0aVgWxnSBpC46sBLOP04-PlGN1_I8EMursDNVj1fBvnSE"
+# ※ 実際の URL をここに記入してください
+discord_webhook_url: "YOUR_WEBHOOK_URL_HERE"
 
 # 通知形式："embed"（埋め込み） または "plain"（テキストのみ）
 message_type: "embed"


### PR DESCRIPTION
## Summary
- add YamlStore#getString overload accepting a default value
- use placeholder for webhook URL in config

## Testing
- `javac $(find src/main/java -name '*.java')` *(fails: package ... does not exist)*


------
https://chatgpt.com/codex/tasks/task_e_6874cbd4e1d083298aa03aa24c39c821